### PR TITLE
Add support for probability when starting the profiler

### DIFF
--- a/src/main/java/software/amazon/profiler/BasePlugin.java
+++ b/src/main/java/software/amazon/profiler/BasePlugin.java
@@ -15,8 +15,10 @@
 package software.amazon.profiler;
 
 import java.io.IOException;
+import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -38,9 +40,15 @@ public class BasePlugin {
     // One profiler per JVM process
     transient volatile Profiler _profiler;
 
-    public synchronized void startProfiler(String profilingGroupName, boolean heapSummaryEnabled) {
+    private final static Random random = ThreadLocalRandom.current();
+
+    public synchronized void startProfiler(String profilingGroupName, boolean heapSummaryEnabled, double probability) {
         Profiler profiler = _profiler;
         if (profiler == null) {
+            if (random.nextDouble() > probability) {
+                log.info("Profiler is not being started for this executor. Probability {}.", probability);
+                return;
+            }
             profiler = createProfiler(profilingGroupName, heapSummaryEnabled);
             log.info("Profiling is being started");
             profiler.start();

--- a/src/main/java/software/amazon/profiler/BasePlugin.java
+++ b/src/main/java/software/amazon/profiler/BasePlugin.java
@@ -45,7 +45,7 @@ public class BasePlugin {
     public synchronized void startProfiler(String profilingGroupName, boolean heapSummaryEnabled, double probability) {
         Profiler profiler = _profiler;
         if (profiler == null) {
-            if (random.nextDouble() > probability) {
+            if (random.nextDouble() >= probability) {
                 log.info("Profiler is not being started for this executor. Probability {}.", probability);
                 return;
             }

--- a/src/main/java/software/amazon/profiler/ProfilingContext.java
+++ b/src/main/java/software/amazon/profiler/ProfilingContext.java
@@ -42,6 +42,9 @@ public final class ProfilingContext {
     @Builder.Default
     boolean heapSummaryEnabled = true;
 
+    @Builder.Default
+    double probability = 1.00;
+
     @JsonPOJOBuilder(withPrefix = "")
     public static final class ProfilingContextBuilder {
         // This method declaration is needed only for the JSON annotation

--- a/src/main/java/software/amazon/profiler/SparkDriverPlugin.java
+++ b/src/main/java/software/amazon/profiler/SparkDriverPlugin.java
@@ -39,7 +39,7 @@ public class SparkDriverPlugin extends BasePlugin implements DriverPlugin {
                 ProfilingContext context = getContext();
                 if (context != null && context.isDriverEnabled()) {
                     log.info("Profiling context: " + context);
-                    startProfiler(context.getProfilingGroupName(), context.isHeapSummaryEnabled());
+                    startProfiler(context.getProfilingGroupName(), context.isHeapSummaryEnabled(), 1.00);
                 }
             } catch (IOException | RuntimeException e) {
                 log.warn("Failed to start profiling in driver", e);

--- a/src/main/java/software/amazon/profiler/SparkExecutorPlugin.java
+++ b/src/main/java/software/amazon/profiler/SparkExecutorPlugin.java
@@ -37,7 +37,7 @@ public class SparkExecutorPlugin extends BasePlugin implements ExecutorPlugin {
                 ProfilingContext context = getContext();
                 if (context != null && context.isExecutorEnabled()) {
                     log.info("Profiling context: " + context);
-                    startProfiler(context.getProfilingGroupName(), context.isHeapSummaryEnabled());
+                    startProfiler(context.getProfilingGroupName(), context.isHeapSummaryEnabled(), context.getProbability());
                 }
             } catch (IOException | RuntimeException e) {
                 log.warn("Failed to start profiling in executor", e);

--- a/src/test/java/software/amazon/profiler/BasePluginTest.java
+++ b/src/test/java/software/amazon/profiler/BasePluginTest.java
@@ -38,9 +38,26 @@ public class BasePluginTest {
             }
         };
 
-        plugin.startProfiler("Sample-Spark-App-Beta", true);
+        plugin.startProfiler("Sample-Spark-App-Beta", true, 1.0);
         verify(profiler, times(1)).start();
         Assertions.assertEquals(profiler, plugin._profiler);
+    }
+
+    @Test
+    public void testStartProfilerZeroProbability() {
+        Profiler profiler = mock(Profiler.class);
+        when(profiler.isRunning()).thenReturn(true);
+
+        BasePlugin plugin = new BasePlugin() {
+            @Override
+            public Profiler createProfiler(String profilingGroupName, boolean heapSummaryEnabled) {
+                return profiler;
+            }
+        };
+
+        plugin.startProfiler("Sample-Spark-App-Beta", true, 0.00);
+        verify(profiler, times(0)).start();
+        Assertions.assertNull(plugin._profiler);
     }
 
     @Test

--- a/src/test/java/software/amazon/profiler/ProfilingContextTest.java
+++ b/src/test/java/software/amazon/profiler/ProfilingContextTest.java
@@ -49,4 +49,29 @@ public class ProfilingContextTest {
         Assertions.assertTrue(context.isHeapSummaryEnabled());
     }
 
+    @Test
+    public void testDefaultProfilingGroupProbability() {
+        ProfilingContext context = ProfilingContext.builder()
+                                                   .build();
+
+        Assertions.assertEquals(1.00, context.getProbability());
+    }
+
+    @Test
+    public void testProfilingGroupProbabilitySet() {
+        ProfilingContext context = ProfilingContext.builder()
+                                                   .probability(0.05)
+                                                   .build();
+
+        Assertions.assertEquals(0.05, context.getProbability());
+    }
+
+    @Test
+    public void testProfilingGroupProbabilityOutsideNorm() {
+        ProfilingContext context = ProfilingContext.builder()
+                                                   .probability(15.12)
+                                                   .build();
+        Assertions.assertEquals(15.12, context.getProbability());
+    }
+
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding an optional field to add a probability for the profiler to be started. This is to avoid hitting throttling issues from CodeGuru for extra large clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
